### PR TITLE
Fixed "Uncaught SyntaxError: Unexpected identifier" after loops.

### DIFF
--- a/tpl.js
+++ b/tpl.js
@@ -46,7 +46,7 @@
 					})
 					.replace(c.evaluate || null, function(match, code) {
 					return "');" + code.replace(/\\'/g, "'")
-										.replace(/[\r\n\t]/g, ' ') + "__p.push('";
+										.replace(/[\r\n\t]/g, ' ') + "; __p.push('";
 					})
 					.replace(/\r/g, '')
 					.replace(/\n/g, '')


### PR DESCRIPTION
Without the change, templates containing blocks like the following one failed with a syntax error:

```
<% items.each(function(item) { %>
    <%= item %>
<% }) %>
```
