### PR TITLE
Template URL for debugging

### DIFF
--- a/tpl.js
+++ b/tpl.js
@@ -180,6 +180,9 @@
 					}
 					content = strip ? tpl.strip(content) : content;
 					
+					// store URL, makes debugging of template errors easier
+					content.url = url;
+					
 					if (config.isBuild && config.inlineText) {
 						buildMap[name] = content;
 					}


### PR DESCRIPTION
Storing template URL in template function. When there is an error in a template (say, reference to an variable that is not available), an error logger can use this information to show in which template file the error occurred.

Thanks for a great plugin - my current Backbone project relies heavily on it.
